### PR TITLE
Fix dol Issue #18 in ModuleNamesImportedByModule.print_kvs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,9 +17,9 @@ display_name = unbox
 packages = find:
 include_package_data = True
 zip_safe = False
-install_requires = 
+install_requires =
 	findimports
-	dol
+	dol>=0.3.49
 	importlib_resources
 	config2py
 	py2store

--- a/unbox/base.py
+++ b/unbox/base.py
@@ -11,7 +11,7 @@ import warnings
 
 from findimports import ModuleGraph
 
-from dol import Collection, KvReader, lazyprop, wrap_kvs
+from dol import Collection, KvReader, lazyprop, wrap_kvs, wrapped_self
 
 ROOT = Union[str, ModuleType]
 NAMES = Iterable[str]
@@ -136,7 +136,10 @@ class ModuleNamesImportedByModule(ModulesImportedByModule):
         return k.imports
 
     def print_kvs(self):
-        for k, v in self.items():
+        # wrapped_self: inside this wrap_kvs-decorated class, ``self`` is the inner
+        # unwrapped store whose keys are module objects, not the key_of_id-decoded module
+        # NAME strings (dol Issue #18). Route through the outer store to print names.
+        for k, v in wrapped_self(self).items():
             print(f'{k}' + '\n' + '\n'.join('    ' + x for x in v))
 
 


### PR DESCRIPTION
`print_kvs` iterated `self.items()` from inside the `@wrap_kvs(key_of_id=modobj_to_modname, ...)`-decorated class, where `self` is the inner **unwrapped** store — so its keys are module *objects*, not the decoded module-name strings. It printed `<Module: json.decoder>` reprs instead of `json.decoder`.

Fix: route through `dol.wrapped_self(self)` (the outer, transform-applying store). Verified locally: `print_kvs` now prints module name strings. Requires `dol>=0.3.49` (ships `wrapped_self`).

No regression test added (repo has no test suite). Refs [i2mint/dol#18](https://github.com/i2mint/dol/issues/18).

https://claude.ai/code/session_01H8PmV6xmMhzV64zi1Twraw